### PR TITLE
Template apps

### DIFF
--- a/global.json
+++ b/global.json
@@ -446,13 +446,6 @@
           "url": "https://raw.githubusercontent.com/feedhenry/template-config/master/screenshots/apps/welcome_project_client/1.png"
         }]
       }, {
-        "id": "welcome_project_android",
-        "name": "Welcome Project-android",
-        "type": "client_native_android",
-        "repoUrl": "git://github.com/feedhenry-templates/welcome-android.git",
-        "githubUrl": "https://github.com/feedhenry-templates/welcome-android.git",
-        "repoBranch": "refs/heads/master"
-      }, {
         "id": "welcome_project_android_gradle",
         "name": "Welcome Project Android Gradle",
         "type": "client_native_android",

--- a/global.json
+++ b/global.json
@@ -290,18 +290,6 @@
       }],
       "appTemplates": ["blank_advanced_hybrid_client", "hello_world_mbaas_instance"]
     }, {
-      "id": "android_project",
-      "priority": 0.85,
-      "name": "Native Android Blank Project",
-      "description": "A FeedHenry primer project with one Android Client App and a cloud instance with a single endpoint",
-      "type": "default",
-      "icon": "icon-android",
-      "category": "Sample Projects",
-      "screenshots": [{
-        "url": "https://raw.githubusercontent.com/feedhenry-templates/blank-android-app/master/screenshots/androidproject_container.png"
-      }],
-      "appTemplates": ["blank_native_android_client", "hello_world_mbaas_instance"]
-    }, {
       "id": "android_gradle_project",
       "priority": 0.85,
       "name": "Native Gradle Android Blank Project",
@@ -575,20 +563,6 @@
       "repoBranch": "refs/heads/master",
       "icon": "icon-cloud",
       "category": "Sample Apps"
-    }, {
-      "id": "blank_native_android_client",
-      "name": "Blank Native Android App",
-      "type": "client_native_android",
-      "priority": 0.45,
-      "description": "Native Android Blank App which echos your name via the Cloud",
-      "repoUrl": "git://github.com/feedhenry-templates/blank-android-app.git",
-      "githubUrl": "https://github.com/feedhenry-templates/blank-android-app.git",
-      "repoBranch": "refs/heads/master",
-      "icon": "icon-android",
-      "category": "Blank Apps",
-      "screenshots": [{
-        "url": "https://raw.githubusercontent.com/feedhenry-templates/blank-android-app/master/screenshots/androidproject_container.png"
-      }]
     }, {
       "id": "blank_native_android_gradle_client",
       "name": "Blank Native Android Gradle App",

--- a/global.json
+++ b/global.json
@@ -44,12 +44,24 @@
           "url": "https://raw.githubusercontent.com/feedhenry/fh-template-apps/master/screenshots/apps/sync_app/cordova-sync.png"
         }]
       }, {
-        "id": "sync_ios_app",
-        "name": "Sync iOS App",
+        "id": "sync_ios_objectivec_app",
+        "name": "Sync iOS (Objective-C) App",
         "type": "client_native_ios",
         "repoUrl": "git://github.com/feedhenry-templates/sync-ios-app.git",
         "githubUrl": "https://github.com/feedhenry-templates/sync-ios-app.git",
         "repoBranch": "refs/heads/cocoapods",
+        "icon": "icon-apple",
+        "category": "Sample Apps",
+        "screenshots": [{
+          "url": "https://raw.githubusercontent.com/feedhenry/fh-template-apps/master/screenshots/apps/sync_app/ios-sync.png"
+        }]
+      }, {
+        "id": "sync_ios_swift_app",
+        "name": "Sync iOS (Swift) App",
+        "type": "client_native_ios",
+        "repoUrl": "git://github.com/feedhenry-templates/sync-ios-swift.git",
+        "githubUrl": "https://github.com/feedhenry-templates/sync-ios-swift.git",
+        "repoBranch": "refs/heads/master",
         "icon": "icon-apple",
         "category": "Sample Apps",
         "screenshots": [{

--- a/global.json
+++ b/global.json
@@ -447,6 +447,13 @@
         "repoUrl": "git://github.com/feedhenry-templates/welcome-cloud.git",
         "githubUrl": "https://github.com/feedhenry-templates/welcome-windows.git",
         "repoBranch": "refs/heads/master"
+      }, {
+        "id": "welcome_project_ios_objectivec",
+        "name": "Welcome Project iOS",
+        "type": "client_native_ios",
+        "repoUrl": "git://github.com/feedhenry-templates/welcome-ios.git",
+        "githubUrl": "https://github.com/feedhenry-templates/welcome-ios.git",
+        "repoBranch": "refs/heads/master"
       }]
     }, {
       "id": "mobile_spec_project",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-config",
-  "version": "3.7.2",
+  "version": "3.8.0",
   "description": "FeedHenry Template Applications",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
See: 

* [FH-2474](https://issues.jboss.org/browse/FH-2474) - Remove Android ANT templates from the Studio
* [FH-2622](https://issues.jboss.org/browse/FH-2622) - Add welcome iOS Obj-C template in studio
* [FH-2620](https://issues.jboss.org/browse/FH-2620) - Add sync iOS swift template in studio