### PR TITLE
RHMAP-7527 - Add an npm start script to webapp template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-config",
-  "version": "3.28.1",
+  "version": "3.28.2",
   "description": "FeedHenry Template Applications",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Adds an `npm start` script for OSE3 - template changes are now on master so will be included in this master build.

https://github.com/feedhenry/fh-advanced-webapp-blank-app/pull/5
https://issues.jboss.org/browse/RHMAP-7472