### PR TITLE
bump for api mapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-config",
-  "version": "3.28.6",
+  "version": "3.28.7",
   "description": "FeedHenry Template Applications",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-template-apps
 sonar.projectName=fh-template-apps-nightly-master
-sonar.projectVersion=3.28.5
+sonar.projectVersion=3.28.7
 
 sonar.sources=.
 sonar.language=js


### PR DESCRIPTION
bumping for API mapper, update on:
https://github.com/feedhenry-templates/fh-api-mapper/pull/69

Looks like in #191 the `sonar` properties file was forgotten to bump up as well 