### PR TITLE
Bump version to apply npm rollback in templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-config",
-  "version": "3.32.1",
+  "version": "3.32.2",
   "description": "FeedHenry Template Applications",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-template-apps
 sonar.projectName=fh-template-apps-nightly-master
-sonar.projectVersion=3.32.1
+sonar.projectVersion=3.32.2
 
 sonar.sources=.
 sonar.language=js


### PR DESCRIPTION
This bump will include this PRs:

* https://github.com/feedhenry-templates/saml-cordova-app/pull/9
* https://github.com/feedhenry-templates/sync-cordova-app/pull/10
* https://github.com/feedhenry-templates/welcome-app/pull/9
* https://github.com/feedhenry-templates/helloworld-app/pull/15
* https://github.com/feedhenry-templates/quickstart-backbone-app/pull/7
* https://github.com/feedhenry-templates/quickstart-angular-app/pull/8
* https://github.com/feedhenry-templates/quickstart-ionic-app/pull/10
