### PR TITLE
Updated raincatcher getting started guide link within raincatcher pro…

### DIFF
--- a/global.json
+++ b/global.json
@@ -618,7 +618,7 @@
       "id": "wfm_project",
       "priority": 0.30,
       "name": "WFM Demo Project",
-      "description": "A demo project showcasing the reusable WFM modules. Note: Using openshift.feedhenry.com access via your OpenShift account is limited to using the small OpenShift Gear. Due to WFM template's non-trivial functionality you may have stability issues using the small gear. Get Started: https://github.com/feedhenry-staff/wfm-doc/blob/master/Getting-Started.md",
+      "description": "A demo project showcasing the reusable WFM modules. Note: Using openshift.feedhenry.com access via your OpenShift account is limited to using the small OpenShift Gear. Due to WFM template's non-trivial functionality you may have stability issues using the small gear. Get Started: https://github.com/feedhenry-raincatcher/raincatcher-documentation/blob/master/Getting-Started.md",
       "type": "default",
       "icon": "icon-globe",
       "category": "Tech Preview",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-config",
-  "version": "4.3.9",
+  "version": "4.3.10",
   "description": "FeedHenry Template Applications",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-template-apps
 sonar.projectName=fh-template-apps-nightly-master
-sonar.projectVersion=4.3.9
+sonar.projectVersion=4.3.10
 
 sonar.sources=.
 sonar.language=js


### PR DESCRIPTION
## Issue
Getting started guide for Raincatcher has been moved from wfm-docs to a different location:
https://github.com/feedhenry-raincatcher/raincatcher-documentation/blob/master/Getting-Started.md

## Solution
Update getting started guide link within raincatcher project template description  to direct to this new location.

## JIRA Ticket
https://issues.jboss.org/browse/RHMAP-11367