### PR TITLE
RHMAP-3073 - version bump to include code snippets to use fh.auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-config",
-  "version": "4.3.15",
+  "version": "4.3.16",
   "description": "FeedHenry Template Applications",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-template-apps
 sonar.projectName=fh-template-apps-nightly-master
-sonar.projectVersion=4.3.13
+sonar.projectVersion=4.3.14
 
 sonar.sources=.
 sonar.language=js


### PR DESCRIPTION
# Motivation 
Studio Preview/Local Development for Web Apps does not handle $fh.auth calls correctly

A new auth end was added to handle $fh.auth requests correctly in fh-mbaas-api.

fh-mbaas-api version needed to be updated in all cloud app templates

# Result
Version bump required to regenerate template apps 