### PR TITLE
Bump raincatcher apps version to 2.2.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -427,7 +427,7 @@
         "type": "client_advanced_hybrid",
         "repoUrl": "git://github.com/feedhenry-raincatcher/raincatcher-demo-mobile.git",
         "githubUrl": "https://github.com/feedhenry-raincatcher/raincatcher-demo-mobile.git",
-        "repoBranch": "refs/heads/v2.1.0-alpha",
+        "repoBranch": "refs/tags/2.2.0",
         "icon": "icon-cordova",
         "category": "Sample Apps",
         "screenshots": [{
@@ -439,7 +439,7 @@
         "type": "webapp_advanced",
         "repoUrl": "git://github.com/feedhenry-raincatcher/raincatcher-demo-portal.git",
         "githubUrl": "https://github.com/feedhenry-raincatcher/raincatcher-demo-portal.git",
-        "repoBranch": "refs/heads/v2.1.0-alpha",
+        "repoBranch": "refs/tags/2.2.0",
         "category": "Sample Apps",
         "screenshots": [{
           "url": "https://raw.githubusercontent.com/feedhenry/fh-template-apps/master/screenshots/apps/wfm_project/wfm-portal.png"
@@ -450,7 +450,7 @@
         "type": "cloud_nodejs",
         "repoUrl": "git://github.com/feedhenry-raincatcher/raincatcher-demo-cloud.git",
         "githubUrl": "https://github.com/feedhenry-raincatcher/raincatcher-demo-cloud.git",
-        "repoBranch": "refs/heads/v2.1.0-alpha",
+        "repoBranch": "refs/tags/2.2.0",
         "category": "Sample Apps",
         "forcedSelection": true
       }]
@@ -1382,7 +1382,7 @@
           "type": "cloud_nodejs",
           "repoUrl": "git://github.com/feedhenry-raincatcher/raincatcher-demo-auth.git",
           "githubUrl": "https://github.com/feedhenry-raincatcher/raincatcher-demo-auth.git",
-          "repoBranch": "refs/heads/v2.1.0-alpha",
+          "repoBranch": "refs/tags/2.2.0",
           "category": "Custom Service",
           "forcedSelection": true
         }]


### PR DESCRIPTION
Bump template for Raincatcher to versions 2.2.0

This targets:
- https://github.com/feedhenry-raincatcher/raincatcher-demo-auth/releases/tag/2.2.0
- https://github.com/feedhenry-raincatcher/raincatcher-demo-cloud/releases/tag/2.2.0
- https://github.com/feedhenry-raincatcher/raincatcher-demo-portal/releases/tag/2.2.0
- https://github.com/feedhenry-raincatcher/raincatcher-demo-mobile/releases/tag/2.2.0

ping @nialldonnellyfh