### PR TITLE
Rhmap 13678 template apps stage

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,11 @@ module.exports = function (grunt) {
         src: ['**/*', '**/.*']
       }
     },
-    clone: ["tmp/global.json", 'tmp/global-forms.json'],
+    clone: ["global.json", 'global-forms.json'],
+    tag: ["global.json", 'global-forms.json'],
+    branch: ["global.json", 'global-forms.json'],
+    push: ["global.json", 'global-forms.json'],
+    gitrefs: ["global.json", 'global-forms.json'],
     download: ["tmp/global.json", 'tmp/global-forms.json'],
     format: ["global.json", 'global-forms.json']
   });
@@ -41,5 +45,4 @@ module.exports = function (grunt) {
 
   grunt.registerTask('archive', ['clean', 'copy', 'clone', 'download', 'compress']);
   grunt.registerTask('default', ['archive']);
-
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "4.11.3",
   "description": "FeedHenry Template Applications",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "version": "sed -i.bak \"s/sonar.projectVersion=.*/sonar.projectVersion=${npm_package_version}/\" sonar-project.properties && rm sonar-project.properties.bak && git add sonar-project.properties"
   },
   "repository": {
     "type": "git",

--- a/tasks/branch.js
+++ b/tasks/branch.js
@@ -1,0 +1,36 @@
+
+'use strict';
+
+module.exports = function(grunt) {
+
+  var templateHelper = require('./lib/templateHelper').init(grunt);
+  var _ = require('underscore');
+
+  function branchAppTemplates(filepath, branch) {
+    grunt.config.set('gitcheckout', {});
+
+    var globalJson = grunt.file.readJSON(filepath);
+
+    templateHelper.walkObjects(globalJson.show, function (obj) {
+      var prefix = 'gitcheckout.' + obj.id + '.options';
+      if (_.has(obj, 'repoUrl') && _.has(obj, 'repoBranch')) {
+        grunt.config.set(prefix + '.branch', branch);
+        grunt.config.set(prefix + '.create', true);
+        grunt.config.set(prefix + '.cwd', 'tmp/' + obj.id);
+      }
+    });
+    if (_.isEmpty(grunt.config.get('gitcheckout'))) {
+      grunt.log.ok("No git apps defined in " + filepath);
+    } else {
+      grunt.task.run('gitcheckout');
+    }
+  }
+
+  grunt.registerMultiTask('branch', 'Create a branch on all defined app repos', function () {
+    var branch = grunt.option('git-branch');
+    this.filesSrc.forEach(function (filepath) {
+      branchAppTemplates(filepath, branch);
+    });
+  });
+
+};

--- a/tasks/clone.js
+++ b/tasks/clone.js
@@ -6,7 +6,7 @@ module.exports = function(grunt) {
   var templateHelper = require('./lib/templateHelper').init(grunt);
   var _ = require('underscore');
 
-  function cloneAppTemplates(filepath) {
+  function cloneAppTemplates(filepath, cloneDepth) {
     grunt.config.set('gitclone', {});
 
     var globalJson = grunt.file.readJSON(filepath);
@@ -14,23 +14,24 @@ module.exports = function(grunt) {
     templateHelper.walkObjects(globalJson.show, function (obj) {
       var prefix = 'gitclone.' + obj.id + '.options';
       if (_.has(obj, 'repoUrl') && _.has(obj, 'repoBranch')) {
+        var repoUrl = obj.repoUrl.replace('git://github.com/','git@github.com:');
         grunt.config.set(prefix + '.directory', 'tmp/' + obj.id);
-        grunt.config.set(prefix + '.repository', obj.repoUrl);
+        grunt.config.set(prefix + '.repository', repoUrl);
         grunt.config.set(prefix + '.branch', obj.repoBranch.split('/').pop());
-        grunt.config.set(prefix + '.depth', 1);
+        grunt.config.set(prefix + '.depth', cloneDepth);
       }
     });
     if (_.isEmpty(grunt.config.get('gitclone'))) {
       grunt.log.ok("No git apps defined in " + filepath);
     } else {
-      grunt.task.run('gitclone')
+      grunt.task.run('gitclone');
     }
   }
 
   grunt.registerMultiTask('clone', 'Clone all defined app repos', function () {
-    grunt.task.requires('copy');
+    var cloneDepth = grunt.option('clone-depth') || 1;
     this.filesSrc.forEach(function (filepath) {
-      cloneAppTemplates(filepath);
+      cloneAppTemplates(filepath, cloneDepth);
     });
   });
 

--- a/tasks/gitrefs.js
+++ b/tasks/gitrefs.js
@@ -1,0 +1,29 @@
+
+'use strict';
+
+module.exports = function(grunt) {
+
+  var templateHelper = require('./lib/templateHelper').init(grunt);
+  var _ = require('underscore');
+
+  function updateGitRefs(filepath, gitRef) {
+    var globalJson = grunt.file.readJSON(filepath);
+
+    templateHelper.walkObjects(globalJson.show, function (obj) {
+      if (_.has(obj, 'repoUrl') && _.has(obj, 'repoBranch')) {
+        obj.repoBranch = gitRef;
+      }
+    });
+
+    grunt.file.write(filepath, JSON.stringify(globalJson, null, '  ') + '\n');
+  }
+
+  grunt.registerMultiTask('gitrefs', 'Update files for a release', function () {
+    var ref = grunt.option('git-ref');
+
+    this.filesSrc.forEach(function (filepath) {
+      updateGitRefs(filepath, ref);
+    });
+  });
+
+};

--- a/tasks/push.js
+++ b/tasks/push.js
@@ -1,0 +1,36 @@
+
+'use strict';
+
+module.exports = function(grunt) {
+
+  var templateHelper = require('./lib/templateHelper').init(grunt);
+  var _ = require('underscore');
+
+  function pushAppTemplates(filepath, branch) {
+    grunt.config.set('gitpush', {});
+
+    var globalJson = grunt.file.readJSON(filepath);
+
+    templateHelper.walkObjects(globalJson.show, function (obj) {
+      var prefix = 'gitpush.' + obj.id + '.options';
+      if (_.has(obj, 'repoUrl') && _.has(obj, 'repoBranch')) {
+        grunt.config.set(prefix + '.branch', branch);
+        grunt.config.set(prefix + '.tags', true);
+        grunt.config.set(prefix + '.cwd', 'tmp/' + obj.id);
+      }
+    });
+    if (_.isEmpty(grunt.config.get('gitpush'))) {
+      grunt.log.ok("No git apps defined in " + filepath);
+    } else {
+      grunt.task.run('gitpush');
+    }
+  }
+
+  grunt.registerMultiTask('push', 'Push branch and tags on all defined app repos', function () {
+    var branch = grunt.option('git-branch') || null;
+    this.filesSrc.forEach(function (filepath) {
+      pushAppTemplates(filepath, branch);
+    });
+  });
+
+};

--- a/tasks/tag.js
+++ b/tasks/tag.js
@@ -1,0 +1,35 @@
+
+'use strict';
+
+module.exports = function(grunt) {
+
+  var templateHelper = require('./lib/templateHelper').init(grunt);
+  var _ = require('underscore');
+
+  function tagAppTemplates(filepath, tag) {
+    grunt.config.set('gittag', {});
+
+    var globalJson = grunt.file.readJSON(filepath);
+
+    templateHelper.walkObjects(globalJson.show, function (obj) {
+      var prefix = 'gittag.' + obj.id + '.options';
+      if (_.has(obj, 'repoUrl') && _.has(obj, 'repoBranch')) {
+        grunt.config.set(prefix + '.tag', tag);
+        grunt.config.set(prefix + '.cwd', 'tmp/' + obj.id);
+      }
+    });
+    if (_.isEmpty(grunt.config.get('gittag'))) {
+      grunt.log.ok("No git apps defined in " + filepath);
+    } else {
+      grunt.task.run('gittag');
+    }
+  }
+
+  grunt.registerMultiTask('tag', 'Tag all defined app repos', function () {
+    var tag = grunt.option('git-tag');
+    this.filesSrc.forEach(function (filepath) {
+      tagAppTemplates(filepath, tag);
+    });
+  });
+
+};


### PR DESCRIPTION
Adds new grunt tasks to support automating the update of template app repos for a release.

Add clone-depth option, default is 1:
```
grunt clean clone --clone-depth=9999
```

Add branch task, create a branch in all app repos:

```
grunt branch --git-branch RH_v9.9.x
```

Add tag task, create a tag in all app repos:

```
grunt tag --git-tag rh-release-9.9.1-rc1
```

Add push task:

```
grunt push --git-branch RH_v9.9.x
grunt push --git-branch :RH_v9.9.x # Delete a branch
grunt push --git-branch :refs/tags/rh-release-9.9.1-rc1 #Delete a tag
```

Add gitrefs task, updates all app configs to use the given ref:

```
grunt gitrefs  --git-ref refs/heads/RH_v9.9.x
```