### PR TITLE
Version bump for RHMAP-14051

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-config",
-  "version": "4.11.5",
+  "version": "4.12.5",
   "description": "FeedHenry Template Applications",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-template-apps
 sonar.projectName=fh-template-apps-nightly-master
-sonar.projectVersion=4.11.5
+sonar.projectVersion=4.12.5
 
 sonar.sources=.
 sonar.language=js


### PR DESCRIPTION
Related of:

* [FH-2771](https://issues.jboss.org/browse/FH-2771) - Include Bagde Info Icons on Cloud App templates
* [RHMAP-14051](https://issues.jboss.org/browse/RHMAP-14051) - Templates have broken links in Docs tab in studio