### PR TITLE
Update fh-wfm template apps

### DIFF
--- a/global.json
+++ b/global.json
@@ -477,7 +477,7 @@
             "type": "client_advanced_hybrid",
             "repoUrl": "git://github.com/feedhenry-raincatcher/raincatcher-demo-mobile.git",
             "githubUrl": "https://github.com/feedhenry-raincatcher/raincatcher-demo-mobile.git",
-            "repoBranch": "refs/tags/v2.9.0",
+            "repoBranch": "refs/tags/v2.10.0",
             "icon": "icon-cordova",
             "category": "Sample Apps",
             "screenshots": [
@@ -492,7 +492,7 @@
             "type": "webapp_advanced",
             "repoUrl": "git://github.com/feedhenry-raincatcher/raincatcher-demo-portal.git",
             "githubUrl": "https://github.com/feedhenry-raincatcher/raincatcher-demo-portal.git",
-            "repoBranch": "refs/tags/v2.7.1",
+            "repoBranch": "refs/tags/v2.8.0",
             "category": "Sample Apps",
             "screenshots": [
               {
@@ -506,7 +506,7 @@
             "type": "cloud_nodejs",
             "repoUrl": "git://github.com/feedhenry-raincatcher/raincatcher-demo-cloud.git",
             "githubUrl": "https://github.com/feedhenry-raincatcher/raincatcher-demo-cloud.git",
-            "repoBranch": "refs/tags/v3.0.0",
+            "repoBranch": "refs/tags/v3.1.0",
             "category": "Sample Apps",
             "forcedSelection": true
           }
@@ -1587,7 +1587,7 @@
             "type": "cloud_nodejs",
             "repoUrl": "git://github.com/feedhenry-raincatcher/raincatcher-demo-auth.git",
             "githubUrl": "https://github.com/feedhenry-raincatcher/raincatcher-demo-auth.git",
-            "repoBranch": "refs/tags/v2.3.0",
+            "repoBranch": "refs/tags/v2.4.0",
             "category": "Custom Service",
             "forcedSelection": true
           }


### PR DESCRIPTION
Bump version of fh-wfm template apps and fh-wfm template auth service for 3.17.0 rc3 to the following releases: 

**fh-wfm-demo-auth:**  v2.4.0
**fh-wfm-demo-cloud:**  v3.1.0
**fh-wfm-demo-portal:**  v2.8.0
**fh-wfm-demo-mobile:**  v2.10.0