### PR TITLE
RHMAP-16775 - Use the CentOS base nodejs slave 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 //https://github.com/feedhenry/fh-pipeline-library
 import org.feedhenry.Utils
 
-fhBuildNode {
+fhBuildNode(['label': 'nodejs']) {
 
     def utils = new Utils()
 


### PR DESCRIPTION
* Use a version of git (> 1.8) compatible with the grunt tasks.

Jira:
* https://issues.jboss.org/browse/RHMAP-16775