### PR TITLE
fix: removes xamarin templates (rhmap-20004)

### DIFF
--- a/global.json
+++ b/global.json
@@ -180,17 +180,6 @@
             "icon": "icon-apple",
             "category": "Sample Apps",
             "screenshots": []
-          },
-          {
-            "id": "saml_xamarin_app",
-            "name": "SAML Xamarin App",
-            "type": "client_xamarin",
-            "repoUrl": "git://github.com/feedhenry-templates/saml-xamarin-app.git",
-            "githubUrl": "https://github.com/feedhenry-templates/saml-xamarin-app.git",
-            "repoBranch": "refs/heads/master",
-            "icon": "icon-xamarin",
-            "category": "Sample Apps",
-            "screenshots": []
           }
         ]
       },
@@ -204,21 +193,6 @@
         "category": "Samples",
         "screenshots": [],
         "appTemplates": [
-          {
-            "id": "pushstarter_xamarin_app",
-            "name": "Simple Xamarin Push App",
-            "type": "client_xamarin",
-            "repoUrl": "git://github.com/feedhenry-templates/pushstarter-xamarin-app.git",
-            "githubUrl": "https://github.com/feedhenry-templates/pushstarter-xamarin-app.git",
-            "repoBranch": "refs/heads/master",
-            "icon": "icon-xamarin",
-            "category": "Sample Apps",
-            "screenshots": [
-              {
-                "url": "https://raw.githubusercontent.com/feedhenry/fh-template-apps/master/screenshots/apps/pushstarter_app/android-push.png"
-              }
-            ]
-          },
           {
             "id": "pushstarter_android_app",
             "name": "Simple Android Push App",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-config",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "FeedHenry Template Applications",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,0 @@
-sonar.projectKey=fh-template-apps
-sonar.projectName=fh-template-apps-nightly-master
-sonar.projectVersion=6.0.1
-
-sonar.sources=.
-sonar.language=js
-sonar.javascript.lcov.reportPath=./coverage/lcov.info
-
-sonar.exclusions=**/node_modules/**/*.js, **/tmp/**/*.js


### PR DESCRIPTION
# Jira link
https://issues.jboss.org/browse/RHMAP-20004

# What
Remove reference to all Xamarin client apps in the studio

# Why
Product decision made to remove Xamarin templates from studio in 4.x

# How
Remove all references to Xamarin client apps within the global.json config file 

# Verification steps
- Deploy changes to a cluster
- Within the studio check the following:
  - create a new project & confirm none of the projects offer you the option to create a Xamarin client app
  - from an existing project, add a new app to the project, select 'Create New App' and verify that you are not offered the option to create any Xamarin client applications