### PR TITLE
[fix]:Remove OpenShift(v2) mBaaS Service which is not so long supported

### DIFF
--- a/global.json
+++ b/global.json
@@ -654,31 +654,6 @@
         ]
       },
       {
-        "name": "OpenShift mBaaS Service",
-        "priority": 0.899,
-        "id": "openshift-mbaas-service",
-        "docs": "https://raw.githubusercontent.com/feedhenry-templates/fh-mbaas-service/master/README.md",
-        "type": "other",
-        "image": "public/img/cloud_plugins/fh.png",
-        "category": "Platform Service",
-        "description": "fh-mbaas service for use in OpenShift MBaaS Targets. Required for fh.forms API.",
-        "appTemplates": [
-          {
-            "id": "openshift-mbaas-service-instance",
-            "name": "OpenShift mBaaS Service",
-            "type": "cloud_nodejs",
-            "repoUrl": "git://github.com/feedhenry-templates/fh-mbaas-service.git",
-            "githubUrl": "https://github.com/feedhenry-templates/fh-mbaas-service.git",
-            "repoBranch": "refs/heads/master",
-            "image": "public/img/cloud_plugins/fh.png",
-            "docs": "https://raw.githubusercontent.com/feedhenry-templates/fh-mbaas-service/master/README.md",
-            "category": "Platform Service",
-            "configuration": [],
-            "forcedSelection": true
-          }
-        ]
-      },
-      {
         "id": "saml-service",
         "priority": 0.892,
         "name": "SAML Service",


### PR DESCRIPTION
# Jira link
https://issues.jboss.org/browse/RHMAP-20187

# What
Remove the service template "OpenShift mBaaS Service"[1] which is to work with OCP V2.
[1] - https://github.com/feedhenry-templates/fh-mbaas-service.git

# Why
The Openshift V2 is not so long supported.

# Local Test:

<img width="1156" alt="screen shot 2018-04-23 at 12 02 49" src="https://user-images.githubusercontent.com/7708031/39123154-dfb3ed64-46ee-11e8-99e7-816828a12ebd.png">
 
