### PR TITLE
fix: bumping version to pick up template changes:RHMAP-21003-v3.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-config",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "FeedHenry Template Applications",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21003


# What
bumping version of fh-template-apps to add android 26 phonegap-plugin-barcodescanner support to cordova templates, 

# Why
Android apps won't build with out this change



# How
bump the version


# Verification Steps
N/A


## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 